### PR TITLE
Add Response interface

### DIFF
--- a/lib/iiif.rb
+++ b/lib/iiif.rb
@@ -1,8 +1,9 @@
 ##
 # IIIF behavior for use with Rack::IIIF middleware
 module IIIF
-  autoload :Response,     'iiif/response'
-  autoload :InfoResponse, 'iiif/info_response'
+  autoload :Response,         'iiif/response'
+  autoload :InfoResponse,     'iiif/info_response'
+  autoload :RedirectResponse, 'iiif/redirect_response'
 
   ##
   # A base class for HTTP request errors.

--- a/lib/iiif/redirect_response.rb
+++ b/lib/iiif/redirect_response.rb
@@ -1,0 +1,29 @@
+module IIIF
+  ##
+  #
+  class RedirectResponse < Response
+    # @!attribute [r] target
+    #   @return [#to_s]  the URI target for redirect
+    attr_reader :target
+
+    ##
+    # @param [#to_s] target  a URI-like string
+    # @status [Integer] status  a valid HTTP status code
+    def initialize(target, status = 303)
+      @target = target
+      self.status = status
+    end
+
+    ##
+    # @return [Symbol] :redirect
+    def type
+      :redirect
+    end
+
+    ##
+    # @see Response#headers
+    def headers
+      @headers ||= { 'Location' => target }
+    end
+  end
+end

--- a/lib/iiif/response.rb
+++ b/lib/iiif/response.rb
@@ -1,10 +1,41 @@
 module IIIF
+  ##
+  # Base class for IIIF responses
   class Response
+    # @!attribute [rw] status
+    #   @return [Integer] the HTTP status code to use in the response
+    attr_accessor :status
+
+    # @!attribute [w] headers
+    #   @return [Hash] a hash of HTTP headers
+    # @!attribute [w] body
+    #   @return [#each] a rack response body
+    attr_writer :body, :headers
+
     ##
     # @abstract implement to return a valid response type
-    # @return [Symbol] one of :info, :image
+    # @return [Symbol] one of :info, :image, :redirect
     def type
       raise NotImplementedError
+    end
+
+    ##
+    # @return [Array<Integer, Hash, #each>] a rack response
+    # @see http://www.rubydoc.info/github/rack/rack/master/file/SPEC
+    def to_response(old_headers = {})
+      [status, old_headers.merge(headers), body]
+    end
+
+    ##
+    # @return [#each] a rack response body
+    def body
+      @body ||= []
+    end
+
+    ##
+    # @return [Hash<#to_s, #to_s>] a hash of HTTP headers
+    def headers
+      @headers ||= {}
     end
   end
 end

--- a/spec/lib/iiif/redirect_response_spec.rb
+++ b/spec/lib/iiif/redirect_response_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper.rb'
+
+describe IIIF::RedirectResponse do
+  subject { described_class.new(target, status) }
+  
+  let(:target) { 'http://example.org/moomin' }
+  let(:status) { 303 }
+  
+  describe '#target' do
+    it 'is the target URI' do
+      expect(subject.target).to eq target
+    end
+  end
+
+  describe '#status' do
+    it 'is the status code' do
+      expect(subject.status).to eq status
+    end
+
+    it 'defaults to 303' do
+      expect(described_class.new(target).status).to eq 303
+    end
+  end
+end


### PR DESCRIPTION
Builds out `#to_response` and implements the middleware handling for responses.
