### PR TITLE
Pass non-IIIF requests through

### DIFF
--- a/lib/rack/iiif.rb
+++ b/lib/rack/iiif.rb
@@ -47,7 +47,7 @@ module Rack
       #   http://iiif.io/api/image/2.1/#uri-syntax
       def call(env)        
         status, headers, response = @app.call(env)
-        response = build_response(Rack::Request.new(env))
+        response = build_response(Rack::Request.new(env)) || response
         [status, headers, response]
       end
       

--- a/spec/lib/rack/iiif_spec.rb
+++ b/spec/lib/rack/iiif_spec.rb
@@ -132,14 +132,10 @@ describe 'middleware' do
       end
 
       describe 'nonsense request' do
-        it 'does not give an info response' do
-          expect(subject.call('PATH_INFO' => "/#{ids.first}/blah/blah").last)
-            .not_to be_a ::IIIF::InfoResponse
-        end
+        it 'passes through' do
+          opts = { 'PATH_INFO' => "/#{ids.first}/blah/blah" }
 
-        it 'does not give an image response' do
-          expect(subject.call('PATH_INFO' => "/#{ids.first}/blah/blah").last)
-            .not_to be_a ::IIIF::ImageResponse
+          expect(subject.call(opts)).to eq base_app.call(opts)
         end
       end
     end


### PR DESCRIPTION
This allows the underlying server to handle requests that don't look like IIIF requests. Results in a 404 in the existing `config.ru`; see: ['Nope.'].
